### PR TITLE
#27 - Provide cleanup-after-each

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 coverage
-npm
+dist
 .opt-in
 .opt-out
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install --save-dev vue-testing-library
 ## Usage
 
 ```
-npm install --save-dev vue-testing-library
+npm install --save-dev @testing-library/vue
                        jest
                        vue-jest
                        babel-jest
@@ -99,7 +99,7 @@ npm install --save-dev vue-testing-library
 
 // src/TestComponent.spec.js
 import 'jest-dom/extend-expect'
-import { render } from 'vue-testing-library'
+import { render } from '@testing-library/vue'
 import TestComponent from './TestComponent'
 
 test('should render HelloWorld', () => {

--- a/cleanup-after-each.js
+++ b/cleanup-after-each.js
@@ -1,0 +1,1 @@
+afterEach(require('./dist').cleanup)

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,9 @@ module.exports = {
     'js',
     'vue'
   ],
+  moduleNameMapper: {
+    '@testing-library/vue': '<rootDir>/src/vue-testing-library.js'
+  },
   coverageDirectory: './coverage',
   collectCoverageFrom: [
     '**/src/**/*.js',
@@ -15,7 +18,7 @@ module.exports = {
   ],
   testPathIgnorePatterns: [
     '/node_modules/',
-    '<rootDir>/npm/',
+    '<rootDir>/dist/',
     '<rootDir>/tests/__tests__/components/'
   ],
   transform: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-testing-library",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,16 +2,17 @@
   "name": "@testing-library/vue",
   "version": "1.0.0",
   "description": "Simple and complete Vue DOM testing utilities that encourage good testing practices.",
-  "main": "npm/vue-testing-library.js",
+  "main": "dist/vue-testing-library.js",
   "scripts": {
     "lint": "eslint --ext .js,.vue .",
     "lint:fix": "eslint --ext .js,.vue . --fix",
     "test": "jest --coverage",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls",
-    "version": "babel src --out-dir npm"
+    "prepublishOnly": "babel src --out-dir dist"
   },
   "files": [
-    "npm"
+    "dist",
+    "cleanup-after-each.js"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@testing-library/vue",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Simple and complete Vue DOM testing utilities that encourage good testing practices.",
   "main": "dist/vue-testing-library.js",
   "scripts": {

--- a/tests/__tests__/debug.js
+++ b/tests/__tests__/debug.js
@@ -1,5 +1,5 @@
 import HelloWorld from './components/HelloWorld'
-import { cleanup, render } from 'vue-testing-library'
+import { cleanup, render } from '@testing-library/vue'
 
 beforeEach(() => {
   jest.spyOn(console, 'log').mockImplementation(() => {})

--- a/tests/__tests__/end-to-end.js
+++ b/tests/__tests__/end-to-end.js
@@ -1,4 +1,4 @@
-import { render, wait } from 'vue-testing-library'
+import { render, wait } from '@testing-library/vue'
 import EndToEnd from './components/EndToEnd'
 
 test('it waits for the data to be loaded', async () => {

--- a/tests/__tests__/fetch.js
+++ b/tests/__tests__/fetch.js
@@ -1,5 +1,5 @@
 import axiosMock from 'axios'
-import { render, fireEvent } from 'vue-testing-library'
+import { render, fireEvent } from '@testing-library/vue'
 import Fetch from './components/Fetch.vue'
 import 'jest-dom/extend-expect'
 

--- a/tests/__tests__/form.js
+++ b/tests/__tests__/form.js
@@ -1,4 +1,4 @@
-import { render, fireEvent } from 'vue-testing-library'
+import { render, fireEvent } from '@testing-library/vue'
 import Login from './components/Login'
 
 test('login form submits', async () => {

--- a/tests/__tests__/integration-with-stubs.js
+++ b/tests/__tests__/integration-with-stubs.js
@@ -1,4 +1,4 @@
-import { render, cleanup } from 'vue-testing-library'
+import { render, cleanup } from '@testing-library/vue'
 import Form from './components/Form'
 
 afterEach(cleanup)

--- a/tests/__tests__/number-display.js
+++ b/tests/__tests__/number-display.js
@@ -1,5 +1,5 @@
 import NumberDisplay from './components/NumberDisplay.vue'
-import { render } from 'vue-testing-library'
+import { render } from '@testing-library/vue'
 import 'jest-dom/extend-expect'
 
 test('calling render with the same component but different props does not remount', async () => {

--- a/tests/__tests__/router/programmatic-routing/index.js
+++ b/tests/__tests__/router/programmatic-routing/index.js
@@ -4,7 +4,7 @@ import App from './components/App.vue'
 import Home from './components/Home.vue'
 import About from './components/About.vue'
 
-import { render, fireEvent } from 'vue-testing-library'
+import { render, fireEvent } from '@testing-library/vue'
 
 const routes = [
   { path: '/', component: Home },

--- a/tests/__tests__/simple-button.js
+++ b/tests/__tests__/simple-button.js
@@ -1,4 +1,4 @@
-import { render, cleanup, fireEvent } from 'vue-testing-library'
+import { render, cleanup, fireEvent } from '@testing-library/vue'
 import SimpleButton from './components/Button'
 
 afterEach(cleanup)

--- a/tests/__tests__/stopwatch.js
+++ b/tests/__tests__/stopwatch.js
@@ -1,5 +1,5 @@
 import StopWatch from './components/StopWatch.vue'
-import { render, wait, fireEvent } from 'vue-testing-library'
+import { render, wait, fireEvent } from '@testing-library/vue'
 import 'jest-dom/extend-expect'
 
 test('unmounts a component', async () => {

--- a/tests/__tests__/stopwatch.js
+++ b/tests/__tests__/stopwatch.js
@@ -1,6 +1,8 @@
 import StopWatch from './components/StopWatch.vue'
-import { render, wait, fireEvent } from '@testing-library/vue'
+import { cleanup, render, wait, fireEvent } from '@testing-library/vue'
 import 'jest-dom/extend-expect'
+
+afterEach(cleanup)
 
 test('unmounts a component', async () => {
   jest.spyOn(console, 'error').mockImplementation(() => {})

--- a/tests/__tests__/validate-plugin.js
+++ b/tests/__tests__/validate-plugin.js
@@ -1,7 +1,7 @@
 import VeeValidate from 'vee-validate'
 import 'jest-dom/extend-expect'
 
-import { render, fireEvent } from 'vue-testing-library'
+import { render, fireEvent } from '@testing-library/vue'
 import Validate from './components/Validate'
 
 test('can validate using plugin', async () => {

--- a/tests/__tests__/vue-router.js
+++ b/tests/__tests__/vue-router.js
@@ -4,13 +4,15 @@ import App from './components/Router/App.vue'
 import Home from './components/Router/Home.vue'
 import About from './components/Router/About.vue'
 
-import { render, fireEvent } from '@testing-library/vue'
+import { cleanup, render, fireEvent } from '@testing-library/vue'
 
 const routes = [
   { path: '/', component: Home },
   { path: '/about', component: About },
   { path: '*', redirect: '/about' }
 ]
+
+afterEach(cleanup)
 
 test('full app rendering/navigating', async () => {
   const { queryByTestId } = render(App, { routes })

--- a/tests/__tests__/vue-router.js
+++ b/tests/__tests__/vue-router.js
@@ -4,7 +4,7 @@ import App from './components/Router/App.vue'
 import Home from './components/Router/Home.vue'
 import About from './components/Router/About.vue'
 
-import { render, fireEvent } from 'vue-testing-library'
+import { render, fireEvent } from '@testing-library/vue'
 
 const routes = [
   { path: '/', component: Home },

--- a/tests/__tests__/vuex.js
+++ b/tests/__tests__/vuex.js
@@ -1,7 +1,9 @@
 import 'jest-dom/extend-expect'
 
 import VuexTest from './components/VuexTest'
-import { render, fireEvent } from '@testing-library/vue'
+import { cleanup, render, fireEvent } from '@testing-library/vue'
+
+afterEach(cleanup)
 
 const store = {
   state: {

--- a/tests/__tests__/vuex.js
+++ b/tests/__tests__/vuex.js
@@ -1,7 +1,7 @@
 import 'jest-dom/extend-expect'
 
 import VuexTest from './components/VuexTest'
-import { render, fireEvent } from 'vue-testing-library'
+import { render, fireEvent } from '@testing-library/vue'
 
 const store = {
   state: {


### PR DESCRIPTION
1. Add cleanup-after-each in same manner as react-testing-library
2. Add jest module name mapper so tests can import the scoped package
3. Update package name in readme