### PR TITLE
Return object from callback.

### DIFF
--- a/src/vue-testing-library.js
+++ b/src/vue-testing-library.js
@@ -17,6 +17,7 @@ function render(
   const localVue = createLocalVue()
   let vuexStore = null
   let router = null
+  let additionalOptions = {}
 
   if (store) {
     const Vuex = require('vuex')
@@ -33,7 +34,7 @@ function render(
   }
 
   if (configurationCb && typeof configurationCb === 'function') {
-    configurationCb(localVue, vuexStore, router)
+    additionalOptions = configurationCb(localVue, vuexStore, router)
   }
 
   if (!mountOptions.propsData && !!mountOptions.props) {
@@ -47,7 +48,8 @@ function render(
     store: vuexStore,
     attachToDocument: true,
     sync: false,
-    ...mountOptions
+    ...mountOptions,
+    ...additionalOptions
   })
 
   mountedWrappers.add(wrapper)


### PR DESCRIPTION
For https://github.com/testing-library/vue-testing-library/issues/47. Allow the returning of an object from the callback of the third parameter of the render function in order to get additional options that may need to use the vue instance once it is created, before the `mount` internally using `@vue/test-utils`.