### PR TITLE
Add Vue Testing Library types from DefinitelyTyped

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Feel free to contribute with more examples!
 
 The TypeScript type definitions are in the
 [DefinitelyTyped repo](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__vue)
-and bundled in Vue Testing Library.
+and bundled with Vue Testing Library.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 - [A simple example](#a-simple-example)
   - [More examples](#more-examples)
 - [Docs](#docs)
+- [Typings](#typings)
 - [License](#license)
 - [Contributors](#contributors)
 
@@ -124,6 +125,12 @@ Feel free to contribute with more examples!
 ## Docs
 
 [**Read the Docs**][docs] | [Edit the docs][docs-edit]
+
+## Typings
+
+The TypeScript type definitions are in the
+[DefinitelyTyped repo](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__vue)
+and bundled in Vue Testing Library.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1418,15 +1418,6 @@
       "resolved": "https://registry.npmjs.org/@types/pretty-format/-/pretty-format-20.0.1.tgz",
       "integrity": "sha512-Oh7wnvVUCtVIWnCHQWe9qDZKn0fGyk5AMq99jXml0x39K59P+z9qe31CNRtop9TceCpS7NmoK+J9eGeCnyFgnw=="
     },
-    "@types/resolve": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
-      "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -1453,6 +1444,21 @@
         "@types/pretty-format": "*"
       }
     },
+<<<<<<< HEAD
+=======
+    "@types/testing-library__vue": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__vue/-/testing-library__vue-2.0.0.tgz",
+      "integrity": "sha512-ZLwWYAMpgIele7N6wZ6J5kRTnzZQw0/0u0VVGP3kJ9L68cBnQpTlJRM4G3crnHNtjhp+eb1TxZ9pkVdRsljHZA==",
+      "requires": {
+        "@types/testing-library__dom": "*",
+        "@vue/test-utils": "^1.0.0-beta.29",
+        "vue": "^2.6.10",
+        "vue-router": "^3.0",
+        "vuex": "^3.0"
+      }
+    },
+>>>>>>> Install types
     "@types/yargs": {
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.2.tgz",
@@ -11585,8 +11591,7 @@
     "vue": {
       "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
-      "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==",
-      "dev": true
+      "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ=="
     },
     "vue-eslint-parser": {
       "version": "5.0.0",
@@ -11654,8 +11659,7 @@
     "vue-router": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.2.tgz",
-      "integrity": "sha512-WssQEHSEvIS1/CI4CO2T8LJdoK4Q9Ngox28K7FDNMTfzNTk2WS5D0dDlqYCaPG+AG4Z8wJkn1KrBc7AhspZJUQ==",
-      "dev": true
+      "integrity": "sha512-WssQEHSEvIS1/CI4CO2T8LJdoK4Q9Ngox28K7FDNMTfzNTk2WS5D0dDlqYCaPG+AG4Z8wJkn1KrBc7AhspZJUQ=="
     },
     "vue-template-compiler": {
       "version": "2.6.10",
@@ -11676,8 +11680,7 @@
     "vuex": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.1.1.tgz",
-      "integrity": "sha512-ER5moSbLZuNSMBFnEBVGhQ1uCBNJslH9W/Dw2W7GZN23UQA69uapP5GTT9Vm8Trc0PzBSVt6LzF3hGjmv41xcg==",
-      "dev": true
+      "integrity": "sha512-ER5moSbLZuNSMBFnEBVGhQ1uCBNJslH9W/Dw2W7GZN23UQA69uapP5GTT9Vm8Trc0PzBSVt6LzF3hGjmv41xcg=="
     },
     "w3c-hr-time": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1418,6 +1418,15 @@
       "resolved": "https://registry.npmjs.org/@types/pretty-format/-/pretty-format-20.0.1.tgz",
       "integrity": "sha512-Oh7wnvVUCtVIWnCHQWe9qDZKn0fGyk5AMq99jXml0x39K59P+z9qe31CNRtop9TceCpS7NmoK+J9eGeCnyFgnw=="
     },
+    "@types/resolve": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
+      "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -1444,8 +1453,6 @@
         "@types/pretty-format": "*"
       }
     },
-<<<<<<< HEAD
-=======
     "@types/testing-library__vue": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/testing-library__vue/-/testing-library__vue-2.0.0.tgz",
@@ -1458,7 +1465,6 @@
         "vuex": "^3.0"
       }
     },
->>>>>>> Install types
     "@types/yargs": {
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.2.tgz",
@@ -3779,9 +3785,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.232",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.232.tgz",
-      "integrity": "sha512-11F8S49B+8AJy5V540BofxvJ1tWP4wZZ0sOre6KF32evS1YSHXiUB7+TQ/mjrfzg1lirnlA8XDdU8CDcJrBCbA==",
+      "version": "1.3.234",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.234.tgz",
+      "integrity": "sha512-SVXY503NJLFAqBx8VdJaO47G+qUQggHgRjZnyjH9/SZ1w0CJpeBrEssNPk71TeKU8OGHdYjjNNHeJ6v+TJoCBg==",
       "dev": true
     },
     "elegant-spinner": {
@@ -3958,6 +3964,12 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
+        "acorn": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
+          "integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
+          "dev": true
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -3978,14 +3990,14 @@
           }
         },
         "espree": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-6.0.0.tgz",
-          "integrity": "sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.0.tgz",
+          "integrity": "sha512-boA7CHRLlVWUSg3iL5Kmlt/xT3Q+sXnKoRYYzj1YeM10A76TEJBbotV5pKbnK42hEUIr121zTv+QLRM5LsCPXQ==",
           "dev": true,
           "requires": {
-            "acorn": "^6.0.7",
+            "acorn": "^7.0.0",
             "acorn-jsx": "^5.0.0",
-            "eslint-visitor-keys": "^1.0.0"
+            "eslint-visitor-keys": "^1.1.0"
           }
         },
         "glob-parent": {
@@ -7750,9 +7762,9 @@
       "dev": true
     },
     "lint-staged": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-9.2.2.tgz",
-      "integrity": "sha512-6VFRfqk8RgZmmd52bvCCEH7cBLfQ97ynZd/uATIGM/Rh4EluZbQdY/HXj9kcx7LhX2Zc4+m+4Z6zS74owovLyA==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-9.2.3.tgz",
+      "integrity": "sha512-ovDmF0c0VJDTP0VmwLetJQ+lVGyNqOkTniwO9S0MOJxGxIExpSRTL56/ZmvXZ1tHNA53GBbXQbfS8RnNGRXFjg==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -7765,6 +7777,7 @@
         "listr": "^0.14.3",
         "log-symbols": "^3.0.0",
         "micromatch": "^4.0.2",
+        "normalize-path": "^3.0.0",
         "please-upgrade-node": "^3.1.1",
         "string-argv": "^0.3.0",
         "stringify-object": "^3.3.0"
@@ -9019,9 +9032,9 @@
       "dev": true
     },
     "p-limit": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
       "dev": true,
       "requires": {
         "p-try": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.5",
     "@testing-library/dom": "^6.0.0",
+    "@types/testing-library__vue": "*",
     "@vue/test-utils": "^1.0.0-beta.29"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #84 

Following the strategy outlined here https://github.com/testing-library/react-testing-library/pull/437, I'm adding [VTL types](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/testing-library__vue) as a dependency.

This means that people installing `@testing-library/vue` would get `@types/testing-library__vue` installed automatically. So from the developers point of view, it's as though the type definitions shipped with the package directly. (adapted from [here](https://blog.johnnyreilly.com/2019/08/symbiotic-definitely-typed.html)).

![imatge](https://user-images.githubusercontent.com/9197791/63222384-4f8f4780-c1a7-11e9-9a34-8b72def130c8.png)
