### PR TITLE
Add Vuetify test to "popular libraries" examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Some included are:
 - [`vue-router`][vue-router-example]
 - [`vee-validate`][vee-validate-example]
 - [`vue-i18n`][vue-i18n-example]
-- [`vuetify`][vuetify]
+- [`vuetify`][vuetify-example]
 
 Feel free to contribute with more examples!
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Some included are:
 - [`vue-router`][vue-router-example]
 - [`vee-validate`][vee-validate-example]
 - [`vue-i18n`][vue-i18n-example]
+- [`vuetify`][vuetify]
 
 Feel free to contribute with more examples!
 
@@ -194,4 +195,5 @@ If you want to lint test files that use Vue Testing Library, you can use the off
 [vue-router-example]: https://github.com/testing-library/vue-testing-library/blob/master/src/__tests__/vue-router.js
 [vee-validate-example]: https://github.com/testing-library/vue-testing-library/blob/master/src/__tests__/validate-plugin.js
 [vue-i18n-example]: https://github.com/testing-library/vue-testing-library/blob/master/src/__tests__/vueI18n.js
+[vuetify]: https://github.com/testing-library/vue-testing-library/blob/master/src/__tests__/vuetify.js
 <!-- prettier-ignore-end -->

--- a/README.md
+++ b/README.md
@@ -195,5 +195,5 @@ If you want to lint test files that use Vue Testing Library, you can use the off
 [vue-router-example]: https://github.com/testing-library/vue-testing-library/blob/master/src/__tests__/vue-router.js
 [vee-validate-example]: https://github.com/testing-library/vue-testing-library/blob/master/src/__tests__/validate-plugin.js
 [vue-i18n-example]: https://github.com/testing-library/vue-testing-library/blob/master/src/__tests__/vueI18n.js
-[vuetify]: https://github.com/testing-library/vue-testing-library/blob/master/src/__tests__/vuetify.js
+[vuetify-example]: https://github.com/testing-library/vue-testing-library/blob/master/src/__tests__/vuetify.js
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
We have a test example for Vuetify, which could be shown in the list of examples for popular libraries.