### PR TITLE
fix(#119): allow vue-router creation through routes param from both jest and mocha

### DIFF
--- a/src/__tests__/vue-router-mocha.js
+++ b/src/__tests__/vue-router-mocha.js
@@ -1,0 +1,16 @@
+import '@testing-library/jest-dom'
+import {render} from '@testing-library/vue'
+
+import About from './components/Router/About.vue'
+
+const routes = []
+test('uses require("vue-router").default when require("vue-router") is undefined (useful for mocha users)', () => {
+  // Test for fix https://github.com/testing-library/vue-testing-library/issues/119
+  jest.mock('vue-router', () => {
+    return undefined
+  })
+
+  expect(() => render(About, {routes})).toThrowError(
+    new TypeError("Cannot read property 'default' of undefined"),
+  )
+})

--- a/src/vue-testing-library.js
+++ b/src/vue-testing-library.js
@@ -36,7 +36,7 @@ function render(
   }
 
   if (routes) {
-    const VueRouter = require('vue-router')
+    const VueRouter = require('vue-router') || require('vue-router').default
     localVue.use(VueRouter)
     router = new VueRouter({
       routes,


### PR DESCRIPTION
This code fixes [issue](https://github.com/testing-library/vue-testing-library/issues/119).