### PR TITLE
Fix vuetify example

### DIFF
--- a/src/__tests__/components/Vuetify.vue
+++ b/src/__tests__/components/Vuetify.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app>
+  <div>
     <v-btn @click="show = true">open</v-btn>
     <v-dialog v-model="show">
       <v-card>
@@ -8,7 +8,17 @@
       </v-card>
     </v-dialog>
     <span v-if="showHint">This is a hint</span>
-  </v-app>
+    <v-menu bottom offset-y>
+      <template v-slot:activator="{on}">
+        <v-btn icon v-on="on">menu</v-btn>
+      </template>
+      <v-list>
+        <v-list-item @click="() => {}">
+          <v-list-item-title>menu item</v-list-item-title>
+        </v-list-item>
+      </v-list>
+    </v-menu>
+  </div>
 </template>
 
 <script>

--- a/src/__tests__/vuetify.js
+++ b/src/__tests__/vuetify.js
@@ -15,10 +15,13 @@ Vue.use(Vuetify)
 // Vuetify requires you to wrap your app with a v-app component that provides
 // a <div data-app="true"> node.
 const renderWithVuetify = (component, options, callback) => {
+  const root = document.createElement('div')
+  root.setAttribute('data-app', 'true')
+
   return render(
     component,
     {
-      container: document.createElement('div').setAttribute('data-app', 'true'),
+      container: document.body.appendChild(root),
       // for Vuetify components that use the $vuetify instance property
       vuetify: new Vuetify(),
       ...options,
@@ -26,6 +29,12 @@ const renderWithVuetify = (component, options, callback) => {
     callback,
   )
 }
+
+test('should set [data-app] attribute on outer most div', () => {
+  const {container} = renderWithVuetify(VuetifyDemoComponent)
+
+  expect(container.attributes.getNamedItem('data-app')).toBeDefined()
+})
 
 test('renders a Vuetify-powered component', async () => {
   const {getByText} = renderWithVuetify(VuetifyDemoComponent)
@@ -49,4 +58,16 @@ test('allows changing props', async () => {
   await updateProps({showHint: true})
 
   expect(queryByText('This is a hint')).toBeInTheDocument()
+})
+
+test('opens a menu', async () => {
+  const {getByText, queryByText} = renderWithVuetify(VuetifyDemoComponent)
+
+  await fireEvent.click(getByText('menu'))
+
+  const menuItem = queryByText('menu item')
+  expect(menuItem).toBeInTheDocument()
+
+  await fireEvent.click(menuItem)
+  expect(queryByText('menu item')).not.toBeInTheDocument()
 })

--- a/src/__tests__/vuetify.js
+++ b/src/__tests__/vuetify.js
@@ -33,7 +33,7 @@ const renderWithVuetify = (component, options, callback) => {
 test('should set [data-app] attribute on outer most div', () => {
   const {container} = renderWithVuetify(VuetifyDemoComponent)
 
-  expect(container.attributes.getNamedItem('data-app')).toBeDefined()
+  expect(container.getAttribute('data-app')).toEqual('true')
 })
 
 test('renders a Vuetify-powered component', async () => {


### PR DESCRIPTION
In #123 I introduced a different approach to integrate with Vuetify. Unfortunately `setAttribute` [always returns undefined](https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute), so `container` eventually was undefined. 

In my own project this lead to bespoken `Unable to localte target [data-app]` warnings when rendering certain vuetify components, such as `v-menu` or `v-dialog`. In this example that went unnoticed, because the example component itself was wrapped within `v-app`.

I fixed that and added tests for it.

_A sidenote: In my own project, adding the container to the body(`document.body.appendChild(root)`) lead to side-effects when interacting with `v-menu`. It seemed like the component was leaking between tests. Even with Jest running as `--runInBand`. However it doesn't happen in this repo. So for this, I am lost 😒. Indeed if I copy paste this test and the tested component over to my project, it fails  because it cannot find the opened `menu item` :/_  