### PR TITLE
feat: Update to DTL with user-event

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Installation](#installation)
-- [A simple example](#a-simple-example)
+- [A basic example](#a-basic-example)
   - [More examples](#more-examples)
 - [Docs](#docs)
 - [Typings](#typings)
@@ -67,10 +67,9 @@ This library has `peerDependencies` listings for `Vue` and
 You may also be interested in installing `jest-dom` so you can use
 [the custom Jest matchers](https://github.com/testing-library/jest-dom#readme).
 
-## A simple example
+## A basic example
 
 ```html
-<!-- TestComponent.vue -->
 <template>
   <div>
     <p>Times clicked: {{ count }}</p>
@@ -80,6 +79,7 @@ You may also be interested in installing `jest-dom` so you can use
 
 <script>
   export default {
+    name: 'Button',
     data: () => ({
       count: 0,
     }),
@@ -93,26 +93,26 @@ You may also be interested in installing `jest-dom` so you can use
 ```
 
 ```js
-// TestComponent.spec.js
-import {render, fireEvent} from '@testing-library/vue'
-import TestComponent from './TestComponent.vue'
+import {screen, render, userEvent} from '@testing-library/vue'
+import Button from './Button'
 
 test('increments value on click', async () => {
-  // The render method returns a collection of utilities to query the component.
-  const {getByText} = render(TestComponent)
+  // The render method renders the provided component into the document
+  render(Button)
 
-  // getByText returns the first matching node for the provided text, and
-  // throws an error if no elements match or if more than one match is found.
-  getByText('Times clicked: 0')
+  // queryByText returns the first matching node for the provided text
+  // or returns null.
+  expect(screen.queryByText('Times clicked: 0')).toBeTruthy()
 
-  // `button` is the actual DOM element.
-  const button = getByText('increment')
+  // getByText returns the first matching node for the provided text
+  // or throws an error.
+  const button = screen.getByText('increment')
 
-  // Dispatch a couple of native click events.
-  await fireEvent.click(button)
-  await fireEvent.click(button)
+  // Click a couple of times.
+  await userEvent.click(button)
+  await userEvent.click(button)
 
-  getByText('Times clicked: 2')
+  expect(screen.queryByText('Times clicked: 2')).toBeTruthy()
 })
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2793,16 +2793,24 @@
       }
     },
     "@testing-library/dom": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.5.7.tgz",
-      "integrity": "sha512-835MiwAxQE7xjSrhpeJbv41UQRmsPJQ0tGfzWiJMdZj2LBbdG5cT8Z44Viv11/XucCmJHr/v8q7VpZnuSimscg==",
+      "version": "7.15.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.15.0-alpha.1.tgz",
+      "integrity": "sha512-GdE0LqTj9ZVxknyO/XpJ2KM/shTw9C2xZB5kkZ+ypXoZJ7Nf/fOrH7H0rZdVYzILznDP5Hh5WeeykTF1uqLNEQ==",
       "requires": {
-        "@babel/runtime": "^7.9.6",
+        "@babel/runtime": "^7.10.2",
         "aria-query": "^4.0.2",
-        "dom-accessibility-api": "^0.4.4",
+        "dom-accessibility-api": "^0.4.5",
         "pretty-format": "^25.5.0"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
         "aria-query": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.0.2.tgz",
@@ -5627,9 +5635,9 @@
       }
     },
     "dom-accessibility-api": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.4.4.tgz",
-      "integrity": "sha512-XBM62jdDc06IXSujkqw6BugEWiDkp6jphtzVJf1kgPQGvfzaU7/jRtRSF/mxc8DBCIm2LS3bN1dCa5Sfxx982A=="
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.4.5.tgz",
+      "integrity": "sha512-HcPDilI95nKztbVikaN2vzwvmv0sE8Y2ZJFODy/m15n7mGXLeOKGiys9qWVbFbh+aq/KYj2lqMLybBOkYAEXqg=="
     },
     "dom-event-types": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.9.6",
-    "@testing-library/dom": "^7.5.7",
+    "@testing-library/dom": "^7.15.0-alpha.1",
     "@types/testing-library__vue": "^2.0.1",
     "@vue/test-utils": "^1.0.3"
   },

--- a/src/__tests__/axios-mock.js
+++ b/src/__tests__/axios-mock.js
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 import axiosMock from 'axios'
-import {render, fireEvent} from '@testing-library/vue'
+import {render, userEvent} from '@testing-library/vue'
 import Component from './components/Fetch.vue'
 
 test('mocks an API call when load-greeting is clicked', async () => {
@@ -12,7 +12,7 @@ test('mocks an API call when load-greeting is clicked', async () => {
 
   const {html, getByText} = render(Component, {props: {url: '/greeting'}})
 
-  await fireEvent.click(getByText('Fetch'))
+  await userEvent.click(getByText('Fetch'))
 
   expect(axiosMock.get).toHaveBeenCalledTimes(1)
   expect(axiosMock.get).toHaveBeenCalledWith('/greeting')

--- a/src/__tests__/components/Button.vue
+++ b/src/__tests__/components/Button.vue
@@ -7,13 +7,13 @@ export default {
   props: {
     text: {
       type: String,
-      default: 'Button Text'
-    }
+      default: 'Button Text',
+    },
   },
   methods: {
-    handleClick(e) {
+    handleClick() {
       this.$emit('click')
-    }
-  }
+    },
+  },
 }
 </script>

--- a/src/__tests__/form.js
+++ b/src/__tests__/form.js
@@ -1,8 +1,8 @@
-import {render, fireEvent} from '@testing-library/vue'
+import {render, userEvent} from '@testing-library/vue'
 import '@testing-library/jest-dom'
 import Form from './components/Form'
 
-// In this test we showcase several ways of targetting DOM elements.
+// In this test we showcase several ways of targeting DOM elements.
 // However, `getByLabelText` should be your top preference when handling
 // form elements.
 // Read 'What queries should I use?' for additional context:
@@ -28,10 +28,10 @@ test('Review form submits', async () => {
   expect(submitButton).toBeDisabled()
 
   const titleInput = getByLabelText(/title of the movie/i)
-  await fireEvent.update(titleInput, fakeReview.title)
+  await userEvent.type(titleInput, fakeReview.title)
 
   const reviewTextarea = getByPlaceholderText('Write an awesome review')
-  await fireEvent.update(reviewTextarea, fakeReview.review)
+  await userEvent.type(reviewTextarea, fakeReview.review)
 
   // Rating Radio buttons.
   const initiallySelectedInput = getByLabelText('Awful')
@@ -40,7 +40,7 @@ test('Review form submits', async () => {
   expect(initiallySelectedInput.checked).toBe(true)
   expect(ratingSelect.checked).toBe(false)
 
-  await fireEvent.update(ratingSelect)
+  await userEvent.click(ratingSelect)
 
   expect(ratingSelect.checked).toBe(true)
   expect(initiallySelectedInput.checked).toBe(false)
@@ -49,14 +49,14 @@ test('Review form submits', async () => {
   const recommendInput = getByRole('checkbox')
 
   expect(recommendInput.checked).toBe(false)
-  await fireEvent.update(recommendInput)
+  await userEvent.click(recommendInput)
   expect(recommendInput.checked).toBe(true)
 
   // Make sure the submit button is enabled.
   expect(submitButton).toBeEnabled()
   expect(submitButton).toHaveAttribute('type', 'submit')
 
-  await fireEvent.click(submitButton)
+  await userEvent.click(submitButton)
 
   // Assert the right event has been emitted.
   expect(emitted()).toHaveProperty('submit')

--- a/src/__tests__/select.js
+++ b/src/__tests__/select.js
@@ -1,27 +1,26 @@
-import {render, fireEvent} from '@testing-library/vue'
+import {render, userEvent} from '@testing-library/vue'
 import '@testing-library/jest-dom'
 import Select from './components/Select'
 
 // In this test file we showcase several ways to interact with a Select element.
 test('Select component', async () => {
-  let optionElement
   const {getByDisplayValue, getByText} = render(Select)
 
   // Get the Select element by using the initially displayed value.
+  // One could also write `getByLabelText('Choose a dinosaur:')`
   const select = getByDisplayValue('Tyrannosaurus')
   expect(select.value).toBe('dino1')
 
   // Update it by manually sending a valid option value.
-  await fireEvent.update(select, 'dino2')
+  // await userEvent.click(getByText(), 'dino2')
+  await userEvent.selectOptions(select, ['dino2'])
   expect(select.value).toBe('dino2')
 
   // We can trigger an update event by directly getting the <option> element.
-  optionElement = getByText('Deinonychus')
-  await fireEvent.update(optionElement)
+  await userEvent.selectOptions(select, getByText('Deinonychus'))
   expect(select.value).toBe('dino3')
 
   // ...even if option is within an <optgroup>.
-  optionElement = getByText('Diplodocus')
-  await fireEvent.update(optionElement)
+  await userEvent.selectOptions(select, getByText('Diplodocus'))
   expect(select.value).toBe('dino4')
 })

--- a/src/__tests__/simple-button.js
+++ b/src/__tests__/simple-button.js
@@ -1,4 +1,4 @@
-import {render, fireEvent} from '@testing-library/vue'
+import {render, userEvent} from '@testing-library/vue'
 import Button from './components/Button'
 import '@testing-library/jest-dom'
 
@@ -24,7 +24,7 @@ test('emits click event when button is clicked', async () => {
   })
 
   // Send a click event.
-  await fireEvent.click(getByRole('button'))
+  await userEvent.click(getByRole('button'))
 
   // Expect that the event emitted a "click" event. We should test for emitted
   // events has they are part of the public API of the component.

--- a/src/__tests__/stopwatch.js
+++ b/src/__tests__/stopwatch.js
@@ -1,45 +1,43 @@
 import '@testing-library/jest-dom'
-import {render, waitFor, fireEvent} from '@testing-library/vue'
+import {render, waitFor, userEvent} from '@testing-library/vue'
 import StopWatch from './components/StopWatch.vue'
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
-test('updates component state', async () => {
-  const {getByTestId, getByText} = render(StopWatch)
+test.todo('the whole test needs improving')
+// test('updates component state', async () => {
+//   const {getByTestId, getByText} = render(StopWatch)
 
-  const startButton = getByText('Start')
-  const elapsedTime = getByTestId('elapsed')
+//   const startButton = getByText('Start')
+//   const elapsedTime = getByTestId('elapsed')
 
-  // Assert initial state.
-  expect(elapsedTime).toHaveTextContent('0ms')
-  getByText('Start')
+//   // Assert initial state.
+//   expect(elapsedTime).toHaveTextContent('0ms')
 
-  await fireEvent.click(startButton)
+//   await userEvent.click(startButton)
 
-  getByText('Stop')
+//   // Wait for one tick of the event loop.
+//   await waitFor(() => {
+//     expect(elapsedTime).not.toHaveTextContent('0ms')
+//   })
+//   const timeBeforeStop = elapsedTime.textContent
 
-  // Wait for one tick of the event loop.
-  await waitFor(() => {
-    expect(elapsedTime).not.toHaveTextContent('0ms')
-  })
-  const timeBeforeStop = elapsedTime.textContent
+//   // Stop the timer.
+//   await userEvent.click(startButton)
 
-  // Stop the timer.
-  await fireEvent.click(startButton)
+//   // Wait for a few milliseconds
+//   await sleep(5)
 
-  // Wait for a few milliseconds
-  await sleep(5)
-
-  // We can't assert a specific amount of time. Instead, we assert that the
-  // content has changed.
-  expect(elapsedTime).toHaveTextContent(timeBeforeStop)
-})
+//   // We can't assert a specific amount of time. Instead, we assert that the
+//   // content has changed.
+//   expect(elapsedTime).toHaveTextContent(timeBeforeStop)
+// })
 
 test('unmounts a component', async () => {
   jest.spyOn(console, 'error').mockImplementation(() => {})
 
   const {unmount, isUnmounted, getByText} = render(StopWatch)
-  await fireEvent.click(getByText('Start'))
+  await userEvent.click(getByText('Start'))
 
   // Destroys a Vue component instance.
   unmount()

--- a/src/__tests__/user-event.js
+++ b/src/__tests__/user-event.js
@@ -1,0 +1,1 @@
+test.todo('implement example of each userEvent API')

--- a/src/__tests__/validate-plugin.js
+++ b/src/__tests__/validate-plugin.js
@@ -2,7 +2,7 @@
 import VeeValidate from 'vee-validate'
 import '@testing-library/jest-dom'
 
-import {render, fireEvent} from '@testing-library/vue'
+import {render, userEvent} from '@testing-library/vue'
 import Validate from './components/Validate'
 
 test('can validate using plugin', async () => {
@@ -19,7 +19,8 @@ test('can validate using plugin', async () => {
   expect(queryByTestId('username-errors')).toBeNull()
 
   const usernameInput = getByPlaceholderText('Username...')
-  await fireEvent.touch(usernameInput)
+  await userEvent.focus(usernameInput)
+  await userEvent.blur(usernameInput)
 
   // After "touching" the input (focusing and blurring), validation error
   // should appear.

--- a/src/__tests__/visibility.js
+++ b/src/__tests__/visibility.js
@@ -1,4 +1,4 @@
-import {render, fireEvent} from '@testing-library/vue'
+import {render, userEvent} from '@testing-library/vue'
 import '@testing-library/jest-dom'
 import Collapsible from './components/Collapsible'
 
@@ -15,13 +15,13 @@ test('Collapsible component', async () => {
 
   // Click button in order to display the collapsed text element
   const button = getByText('Click me')
-  await fireEvent.click(button)
+  await userEvent.click(button)
 
   // Check that text element is visible
   expect(getByText('Text')).toBeVisible()
 
   // Click button to hide the visible text element
-  await fireEvent.click(button)
+  await userEvent.click(button)
 
   // Check that text element is not visible again
   expect(getByText('Text')).not.toBeVisible()

--- a/src/__tests__/vue-apollo.js
+++ b/src/__tests__/vue-apollo.js
@@ -2,7 +2,7 @@
 // This approach only works with apollo-client 2.x and vue-apollo 3.x
 
 import '@testing-library/jest-dom'
-import {render, fireEvent, screen} from '@testing-library/vue'
+import {render, userEvent, screen} from '@testing-library/vue'
 import VueApollo from 'vue-apollo'
 
 // Since vue-apollo doesn't provides a MockProvider for Vue,
@@ -50,12 +50,9 @@ test('mocking queries and mutations', async () => {
     await screen.findByText('Email: alice@example.com'),
   ).toBeInTheDocument()
 
-  await fireEvent.update(
-    screen.getByLabelText('Email'),
-    'alice+new@example.com',
-  )
+  await userEvent.type(screen.getByLabelText('Email'), 'alice+new@example.com')
 
-  await fireEvent.click(screen.getByRole('button', {name: 'Change email'}))
+  await userEvent.click(screen.getByRole('button', {name: 'Change email'}))
 
   expect(
     await screen.findByText('Email: alice+new@example.com'),

--- a/src/__tests__/vue-i18n.js
+++ b/src/__tests__/vue-i18n.js
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom'
-import {render, fireEvent} from '@testing-library/vue'
+import {render, userEvent} from '@testing-library/vue'
 import Vuei18n from 'vue-i18n'
 import Translations from './components/Translations'
 
@@ -32,7 +32,7 @@ test('renders translations', async () => {
 
   expect(getByText('Hello')).toBeInTheDocument()
 
-  await fireEvent.click(getByText('Japanese'))
+  await userEvent.click(getByText('Japanese'))
 
   expect(getByText('こんにちは')).toBeInTheDocument()
 

--- a/src/__tests__/vue-router.js
+++ b/src/__tests__/vue-router.js
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom'
-import {render, fireEvent} from '@testing-library/vue'
+import {render, userEvent} from '@testing-library/vue'
 
 import App from './components/Router/App.vue'
 import Home from './components/Router/Home.vue'
@@ -17,7 +17,7 @@ test('full app rendering/navigating', async () => {
 
   expect(queryByTestId('location-display')).toHaveTextContent('/')
 
-  await fireEvent.click(queryByTestId('about-link'))
+  await userEvent.click(queryByTestId('about-link'))
 
   expect(queryByTestId('location-display')).toHaveTextContent('/about')
 })

--- a/src/__tests__/vueI18n.js
+++ b/src/__tests__/vueI18n.js
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom'
-import {render, fireEvent} from '@testing-library/vue'
+import {render, userEvent} from '@testing-library/vue'
 import Vuei18n from 'vue-i18n'
 import VueI18n from './components/VueI18n'
 
@@ -30,7 +30,7 @@ test('renders translations', async () => {
 
   expect(getByText('Hello')).toBeInTheDocument()
 
-  await fireEvent.click(getByText('Japanese'))
+  await userEvent.click(getByText('Japanese'))
 
   expect(getByText('こんにちは')).toBeInTheDocument()
 

--- a/src/__tests__/vuetify.js
+++ b/src/__tests__/vuetify.js
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 import Vue from 'vue'
-import {render, fireEvent} from '@testing-library/vue'
+import {render, userEvent} from '@testing-library/vue'
 import Vuetify from 'vuetify'
 import VuetifyDemoComponent from './components/Vuetify'
 
@@ -39,7 +39,7 @@ test('should set [data-app] attribute on outer most div', () => {
 test('renders a Vuetify-powered component', async () => {
   const {getByText} = renderWithVuetify(VuetifyDemoComponent)
 
-  await fireEvent.click(getByText('open'))
+  await userEvent.click(getByText('open'))
 
   expect(getByText('Lorem ipsum dolor sit amet.')).toMatchInlineSnapshot(`
     <div
@@ -60,12 +60,12 @@ test('opens a menu', async () => {
   // Menu item is not rendered initially
   expect(queryByText('menu item')).not.toBeInTheDocument()
 
-  await fireEvent.click(openMenuButton)
+  await userEvent.click(openMenuButton)
 
   const menuItem = getByText('menu item')
   expect(menuItem).toBeInTheDocument()
 
-  await fireEvent.click(openMenuButton)
+  await userEvent.click(openMenuButton)
 
   expect(menuItem).toBeInTheDocument()
   expect(menuItem).not.toBeVisible()

--- a/src/__tests__/vuex.js
+++ b/src/__tests__/vuex.js
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom'
-import {render, fireEvent} from '@testing-library/vue'
+import {render, userEvent} from '@testing-library/vue'
 
 import VuexTest from './components/Store/VuexTest'
 import {store} from './components/Store/store'
@@ -19,7 +19,7 @@ function renderVuexTestComponent(customStore) {
 
 test('can render with vuex with defaults', async () => {
   const {getByTestId, getByText} = renderVuexTestComponent()
-  await fireEvent.click(getByText('+'))
+  await userEvent.click(getByText('+'))
 
   expect(getByTestId('count-value')).toHaveTextContent('1')
 })
@@ -28,7 +28,7 @@ test('can render with vuex with custom initial state', async () => {
   const {getByTestId, getByText} = renderVuexTestComponent({
     state: {count: 3},
   })
-  await fireEvent.click(getByText('-'))
+  await userEvent.click(getByText('-'))
 
   expect(getByTestId('count-value')).toHaveTextContent('2')
 })
@@ -48,9 +48,9 @@ test('can render with vuex with custom store', async () => {
   // need to do that.
   const {getByTestId, getByText} = render(VuexTest, {store})
 
-  await fireEvent.click(getByText('+'))
+  await userEvent.click(getByText('+'))
   expect(getByTestId('count-value')).toHaveTextContent('1000')
 
-  await fireEvent.click(getByText('-'))
+  await userEvent.click(getByText('-'))
   expect(getByTestId('count-value')).toHaveTextContent('1000')
 })

--- a/src/vue-testing-library.js
+++ b/src/vue-testing-library.js
@@ -104,6 +104,9 @@ function cleanupAtWrapper(wrapper) {
   }
 }
 
+// The suggested way to interact with elements is by using userEvent.
+//
+// That being said,
 // Vue Testing Library's version of fireEvent will call DOM Testing Library's
 // version of fireEvent plus wait for one tick of the event loop to allow Vue
 // to asynchronously handle the event.


### PR DESCRIPTION
_(Not ready to merge)_.

I feel that using `userEvent` means that `fireEvent.update` is no longer needed. However, I  think we should publish this versions as minor one, so that people can start getting used to `userEvent`, and then remove `fireEvent.update` in a future major version.

Missing bits:
- [ ] Wait until https://github.com/testing-library/dom-testing-library/pull/616 is approved, merged, and released.
- [ ] Fix [issues](https://github.com/testing-library/dom-testing-library/pull/616#issuecomment-643814190) with `textarea`.
- [ ] Improve [stopwatch](src/__tests__/stopwatch.js) test. It was already flaky, and this change broke it again.
- [ ] to consider: given that `fireEvent.update` might not be needed anymore, should we introduce a warning to tell people it is deprecated and use `userEvent` instead? (This should come with an opt-out mechanism, too). 