### PR TITLE
feat: configuration callback composition

### DIFF
--- a/src/__tests__/compose-configuration-callbacks.js
+++ b/src/__tests__/compose-configuration-callbacks.js
@@ -1,0 +1,45 @@
+import '@testing-library/jest-dom'
+import {render, screen} from '@testing-library/vue'
+import Vuei18n from 'vue-i18n'
+import Button from './components/Button'
+
+/**
+ * configuration callbacks may be shared shared between tests / test suites
+ * e.g. for common plugin installation
+ */
+const installGlobalComponents = vue => {
+  vue.component('CustomButton', Button)
+}
+
+const createVuei18nInstall = overrides => vue => {
+  vue.use(Vuei18n)
+
+  return {
+    i18n: new Vuei18n({
+      locale: 'en',
+      fallbackLocale: 'en',
+      ...overrides,
+    }),
+  }
+}
+
+test('can merge multiple configuration callbacks', () => {
+  render(
+    {
+      template: `<custom-button :text="$t('welcome')" />`,
+    },
+    {},
+    [
+      installGlobalComponents,
+      createVuei18nInstall({
+        messages: {
+          en: {
+            welcome: 'Hello',
+          },
+        },
+      }),
+    ],
+  )
+
+  expect(screen.getByRole('button')).toHaveTextContent('Hello')
+})

--- a/src/vue-testing-library.js
+++ b/src/vue-testing-library.js
@@ -47,7 +47,11 @@ function render(
     })
   }
 
-  if (configurationCb && typeof configurationCb === 'function') {
+  if (configurationCb) {
+    if (Array.isArray(configurationCb)) {
+      configurationCb = composeConfigurationCallbacks(configurationCb)
+    }
+
     additionalOptions = configurationCb(localVue, vuexStore, router)
   }
 
@@ -83,6 +87,14 @@ function render(
     },
     ...getQueriesForElement(baseElement),
   }
+}
+
+function composeConfigurationCallbacks(callbacks) {
+  return (...args) =>
+    callbacks.reduce(
+      (mergedReturns, cb) => ({...mergedReturns, ...cb(...args)}),
+      {},
+    )
 }
 
 function cleanup() {


### PR DESCRIPTION
In two projects I am currently working on there are often common configurations needed to install components or plugins - or to setup the router and store instances.

To integrate multiple configuration setups I found it beneficial to compose them automatically like this:

```javascript
render(
   Component, 
   { routes: [ { path: '/email_confirm' } ] }, 
   [
      installGlobalComponents,
      installVueI18n, 
      goToRoute('/email_confirm?token=afhugo823'),
   ]
)
```

I hope the example gives an impression of how this can help one to reuse configurations between tests. This allows to reduce the code that needs to be written per tests and to avoid duplications.

What do you think of this?

Two more things :)
- I removed the check if the configurationCb is a function as it is not actually covered and could lead to strange behaviour (a not-falsy value is passed, but there is no error). If you think this should not be removed I can revert the change or throw an explicit error (e.g. "TypeError: configurationCb should be a function or an array of functions, got `typeof configurationCb`")
- This changes the signature of the function which requires an update for [TypeScript type definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/testing-library__vue/index.d.ts#L43). Would you be interested in merging the definitions inside this repo?