### PR TITLE
Add warning message to fireEvent input and change when called directly #83

### DIFF
--- a/src/__tests__/form.js
+++ b/src/__tests__/form.js
@@ -8,6 +8,7 @@ import Form from './components/Form'
 // Read 'What queries should I use?' for additional context:
 // https://testing-library.com/docs/guide-which-query
 test('Review form submits', async () => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {})
   const fakeReview = {
     title: 'An Awesome Movie',
     review: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
@@ -61,4 +62,5 @@ test('Review form submits', async () => {
   // Assert the right event has been emitted.
   expect(emitted()).toHaveProperty('submit')
   expect(emitted().submit[0][0]).toMatchObject(fakeReview)
+  expect(console.warn).not.toHaveBeenCalled()
 })

--- a/src/vue-testing-library.js
+++ b/src/vue-testing-library.js
@@ -113,9 +113,16 @@ async function fireEvent(...args) {
   dtlFireEvent(...args)
   await waitFor(() => {})
 }
+const changeOrInputEventCalledDirectly = (eventValue, eventKey) =>
+  eventValue && (eventKey === 'change' || eventKey === 'input')
 
 Object.keys(dtlFireEvent).forEach(key => {
   fireEvent[key] = async (...args) => {
+    if (changeOrInputEventCalledDirectly(args[1], key)) {
+      console.warn(
+        'By using "change" or "input", there may be unexpected issues. Please use "update" for a better experience.',
+      )
+    }
     dtlFireEvent[key](...args)
     await waitFor(() => {})
   }


### PR DESCRIPTION
I've made an assumption here that whenever we get a second arg, it's coming from a direct call but would be happy to change it if it's an incorrect assumption. Let me know what y'all think!