### PR TITLE
Fix updateProps Function

### DIFF
--- a/src/__tests__/update-props.js
+++ b/src/__tests__/update-props.js
@@ -14,8 +14,10 @@ test('calling render with the same component but different props does not remoun
   expect(getByTestId('number-display')).toHaveTextContent('1')
 
   await updateProps({number: 2})
-
   expect(getByTestId('number-display')).toHaveTextContent('2')
+
+  await updateProps({number: 3})
+  expect(getByTestId('number-display')).toHaveTextContent('3')
 
   // Assert that, even after updating props, the component hasn't remounted,
   // meaning we are testing the same component instance we rendered initially.

--- a/src/vue-testing-library.js
+++ b/src/vue-testing-library.js
@@ -80,10 +80,7 @@ function render(
     isUnmounted: () => wrapper.vm._isDestroyed,
     html: () => wrapper.html(),
     emitted: () => wrapper.emitted(),
-    updateProps: _ => {
-      wrapper.setProps(_)
-      return waitFor(() => {})
-    },
+    updateProps: _ => wrapper.setProps(_),
     ...getQueriesForElement(baseElement),
   }
 }


### PR DESCRIPTION
# The Problem
I just discovered a bug in one of my projects with the `updateProps` function returned from `render`. Whenever `updateProps` is called multiple times, several errors are logged in the console and Jest is prevented from finishing its test run. This is a huge bug for obvious reasons. Anyone can reproduce this error by grabbing the (currently) latest version of VTL and making multiple `await`ed calls to `updateProps` in a test for a Vue component.

The logged errors seem to be related to asynchronicity. I think that since the `Promise` returned from `updateProps` is different from the one returned from `waitFor`, everything gets thrown out of balance when the developer tries to run tests with multiple `updateProps` calls.

The fix I'm proposing simply returns the `Promise` obtained from `wrapper.setProps` directly. I applied this fix to my `node_modules`, and my tests behaved properly afterwards.


# Changes
* Changed updateProps to return the Promise created from wrapper.setProps.