### PR TITLE
Use `@testing-library/jest-dom` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ npm install --save-dev @testing-library/vue
 This library has `peerDependencies` listings for `Vue` and
 `vue-template-compiler`.
 
-You may also be interested in installing `jest-dom` so you can use [the custom
+You may also be interested in installing `@testing-library/jest-dom` so you can use [the custom
 Jest matchers][jest-dom].
 
 ## A basic example

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ test('increments value on click', async () => {
 })
 ```
 
-> You might want to install [`jest-dom`][jest-dom] to add handy assertions such
+> You might want to install [`@testing-library/jest-dom`][jest-dom] to add handy assertions such
 > as `.toBeInTheDocument()`. In the example above, you could write
 > `expect(screen.queryByText('Times clicked: 0')).toBeInTheDocument()`.
 


### PR DESCRIPTION
Hey folks! I'm just starting out with `@testing-library/vue` and since the README said `You may also be interested in installing jest-dom` I tried installing it, only to then find out it was moved to `@testing-library/jest-dom`, so I had to install the other one.

Perhaps this little change could save other people some time - I'd be happy if you considered accepting it.

Thanks for reading 😊