### PR TITLE
test: remove await from userEvent usage

### DIFF
--- a/src/__tests__/user-event.js
+++ b/src/__tests__/user-event.js
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom'
-import {render} from '@testing-library/vue'
+import {render, waitFor} from '@testing-library/vue'
 import userEvent from '@testing-library/user-event'
 import Form from './components/Form'
 import Select from './components/Select'
@@ -12,7 +12,7 @@ afterEach(() => {
   console.warn.mockRestore()
 })
 
-test('User events in a form', () => {
+test('User events in a form', async () => {
   const fakeReview = {
     title: 'An Awesome Movie',
     review: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
@@ -43,7 +43,7 @@ test('User events in a form', () => {
 
   userEvent.click(wonderfulRadioInput)
   expect(wonderfulRadioInput).toBeChecked()
-  expect(initialSelectedRating).not.toBeChecked()
+  await waitFor(() => expect(initialSelectedRating).not.toBeChecked())
 
   const recommendInput = getByLabelText(/Would you recommend this movie?/i)
   userEvent.click(recommendInput)

--- a/src/__tests__/user-event.js
+++ b/src/__tests__/user-event.js
@@ -12,7 +12,7 @@ afterEach(() => {
   console.warn.mockRestore()
 })
 
-test('User events in a form', async () => {
+test('User events in a form', () => {
   const fakeReview = {
     title: 'An Awesome Movie',
     review: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
@@ -24,16 +24,16 @@ test('User events in a form', async () => {
   expect(submitButton).toBeDisabled()
 
   const titleInput = getByLabelText(/title of the movie/i)
-  await userEvent.type(titleInput, fakeReview.title)
+  userEvent.type(titleInput, fakeReview.title)
   expect(titleInput.value).toEqual(fakeReview.title)
 
   const textArea = getByLabelText(/Your review/i)
-  await userEvent.type(textArea, 'The t-rex went insane!')
+  userEvent.type(textArea, 'The t-rex went insane!')
   expect(textArea.value).toEqual('The t-rex went insane!')
 
-  await userEvent.clear(textArea)
+  userEvent.clear(textArea)
   expect(textArea.value).toEqual('')
-  await userEvent.type(textArea, fakeReview.review)
+  userEvent.type(textArea, fakeReview.review)
   expect(textArea.value).toEqual(fakeReview.review)
 
   const initialSelectedRating = getByLabelText(/Awful/i)
@@ -41,32 +41,32 @@ test('User events in a form', async () => {
   expect(initialSelectedRating).toBeChecked()
   expect(wonderfulRadioInput).not.toBeChecked()
 
-  await userEvent.click(wonderfulRadioInput)
+  userEvent.click(wonderfulRadioInput)
   expect(wonderfulRadioInput).toBeChecked()
   expect(initialSelectedRating).not.toBeChecked()
 
   const recommendInput = getByLabelText(/Would you recommend this movie?/i)
-  await userEvent.click(recommendInput)
+  userEvent.click(recommendInput)
   expect(recommendInput).toBeChecked()
 
   userEvent.tab()
   expect(submitButton).toHaveFocus()
   expect(submitButton).toBeEnabled()
-  await userEvent.type(submitButton, '{enter}')
+  userEvent.type(submitButton, '{enter}')
   expect(emitted().submit[0][0]).toMatchObject(fakeReview)
 
   expect(console.warn).not.toHaveBeenCalled()
 })
 
-test('selecting option with user events', async () => {
+test('selecting option with user events', () => {
   const {getByDisplayValue} = render(Select)
   const select = getByDisplayValue('Tyrannosaurus')
   expect(select.value).toBe('dino1')
 
-  await userEvent.selectOptions(select, 'dino2')
+  userEvent.selectOptions(select, 'dino2')
   expect(select.value).toBe('dino2')
 
-  await userEvent.selectOptions(select, 'dino3')
+  userEvent.selectOptions(select, 'dino3')
   expect(select.value).not.toBe('dino2')
   expect(select.value).toBe('dino3')
 })


### PR DESCRIPTION
`userEvent` is entirely synchronous (except for `type`'s `delay` option which isn't used), so we should use it without `await` and encourage users to do the same.