### PR TITLE
replaced queryByTestId with getByTestId in the vue-router test

### DIFF
--- a/src/__tests__/vue-router.js
+++ b/src/__tests__/vue-router.js
@@ -13,22 +13,22 @@ const routes = [
 
 test('full app rendering/navigating', async () => {
   // Notice how we pass a `routes` object to our render function.
-  const {queryByTestId} = render(App, {routes})
+  const {getByTestId} = render(App, {routes})
 
-  expect(queryByTestId('location-display')).toHaveTextContent('/')
+  expect(getByTestId('location-display')).toHaveTextContent('/')
 
-  await fireEvent.click(queryByTestId('about-link'))
+  await fireEvent.click(getByTestId('about-link'))
 
-  expect(queryByTestId('location-display')).toHaveTextContent('/about')
+  expect(getByTestId('location-display')).toHaveTextContent('/about')
 })
 
 test('setting initial route', () => {
   // The callback function receives three parameters: the Vue instance where
   // the component is mounted, the store instance (if any) and the router
   // object.
-  const {queryByTestId} = render(App, {routes}, (vue, store, router) => {
+  const {getByTestId} = render(App, {routes}, (vue, store, router) => {
     router.push('/about')
   })
 
-  expect(queryByTestId('location-display')).toHaveTextContent('/about')
+  expect(getByTestId('location-display')).toHaveTextContent('/about')
 })


### PR DESCRIPTION
First of all, thank you for all the test examples. It really helped me to set up the test environment on my project.

I found that this test uses `queryBy*` to query the element with `location-display` testid

As it's mentioned in this [link](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#using-query-variants-for-anything-except-checking-for-non-existence), using `getBy*` query might fit better for this test I think.
