### PR TITLE
chore(lint): disable unbound-method rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,5 +17,6 @@ module.exports = {
     'testing-library/no-manual-cleanup': 'off',
     'testing-library/no-await-sync-events': 'off',
     'testing-library/await-fire-event': 'error',
+    'jest/unbound-method': 'off'
   },
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,12 +11,12 @@ module.exports = {
   rules: {
     'no-console': 'off',
     'import/no-unresolved': 'off',
+    'jest/unbound-method': 'off',
 
     'testing-library/no-dom-import': 'off',
     'testing-library/prefer-screen-queries': 'off',
     'testing-library/no-manual-cleanup': 'off',
     'testing-library/no-await-sync-events': 'off',
     'testing-library/await-fire-event': 'error',
-    'jest/unbound-method': 'off'
   },
 }


### PR DESCRIPTION
This rule is currently breaking for some reason in our tests:
https://github.com/testing-library/vue-testing-library/runs/2226695857?check_suite_focus=true