### PR TITLE
VTL for Vue 3: Incorrect TypeScript type definitions for `emitted`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,6 @@
 // Minimum TypeScript Version: 4.0
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import {EmitsOptions} from 'vue'
 import {MountingOptions} from '@vue/test-utils'
 import {queries, EventType, BoundFunctions} from '@testing-library/dom'
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -22,7 +21,7 @@ export interface RenderResult extends BoundFunctions<typeof queries> {
   debug: Debug
   unmount(): void
   html(): string
-  emitted(): EmitsOptions
+  emitted<T = unknown>(): Record<string, T[]>
   rerender(props: object): Promise<void>
 }
 

--- a/types/test.ts
+++ b/types/test.ts
@@ -84,6 +84,11 @@ export function testOptions() {
   })
 }
 
+export function testEmitted() {
+  const {emitted} = render(SomeComponent)
+  emitted().foo; // $ExpectType unknown[]
+}
+
 /*
 eslint
   testing-library/prefer-explicit-assert: "off",


### PR DESCRIPTION
In [the docs for `emitted`](https://testing-library.com/docs/vue-testing-library/api#emitted), it is listed that it is an alias for the `emitted` function of `@vue/test-utils`. However, the type definition of `vue-testing-library`'s `emitted` is not correct.

The `emitted` of `vue-testing-library` is typed as `emitted(): EmitsOptions`. However, `EmitsOptions` (which is imported from `Vue`) is not correct because that's the type used for [defining which events a component can emit](https://v3.vuejs.org/api/options-data.html#emits), not which events have been emitted.

The `emitted` of `@vue/test-utils` is typed as `emitted<T = unknown>(): Record<string, T[]>` (https://github.com/vuejs/vue-test-utils-next/blob/v2.0.0-rc.6/src/vueWrapper.ts#L97).