### PR TITLE
feat: allow passing instantiated Vuex store

### DIFF
--- a/src/__tests__/vuex.js
+++ b/src/__tests__/vuex.js
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom'
 import {render, fireEvent} from '@testing-library/vue'
+import Vuex from 'vuex'
 
 import VuexTest from './components/Store/VuexTest'
 import {store} from './components/Store/store'
@@ -53,4 +54,34 @@ test('can render with vuex with custom store', async () => {
 
   await fireEvent.click(getByText('-'))
   expect(getByTestId('count-value')).toHaveTextContent('1000')
+})
+
+test('can render with an instantiated Vuex store', async () => {
+  const {getByTestId, getByText} = render(VuexTest, {
+    store: new Vuex.Store({
+      state: {count: 3},
+      mutations: {
+        increment(state) {
+          state.count++
+        },
+        decrement(state) {
+          state.count--
+        },
+      },
+      actions: {
+        increment(context) {
+          context.commit('increment')
+        },
+        decrement(context) {
+          context.commit('decrement')
+        },
+      },
+    }),
+  })
+
+  await fireEvent.click(getByText('+'))
+  expect(getByTestId('count-value')).toHaveTextContent('4')
+
+  await fireEvent.click(getByText('-'))
+  expect(getByTestId('count-value')).toHaveTextContent('3')
 })

--- a/src/render.js
+++ b/src/render.js
@@ -31,7 +31,7 @@ function render(
     const Vuex = require('vuex')
     localVue.use(Vuex)
 
-    vuexStore = new Vuex.Store(store)
+    vuexStore = store instanceof Vuex.Store ? store : new Vuex.Store(store)
   }
 
   if (routes) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,6 +40,7 @@ export interface RenderOptions<V extends Vue, S = {}>
   // The props and store options special-cased by Vue Testing Library and NOT passed to mount().
   extends Omit<ThisTypedMountOptions<V>, 'store' | 'props'> {
   props?: object
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   store?: StoreOptions<S>
   routes?: RouteConfig[]
   container?: Element

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,7 +40,6 @@ export interface RenderOptions<V extends Vue, S = {}>
   // The props and store options special-cased by Vue Testing Library and NOT passed to mount().
   extends Omit<ThisTypedMountOptions<V>, 'store' | 'props'> {
   props?: object
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   store?: StoreOptions<S>
   routes?: RouteConfig[]
   container?: Element

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import Vuex from 'vuex'
 import {render, fireEvent, screen, waitFor} from '@testing-library/vue'
 
 declare const elem: Element
@@ -124,6 +125,30 @@ export function testConfigCallback() {
     localVue.use(ExamplePlugin)
     store.replaceState({foo: 'bar'})
     router.onError(error => console.log(error.message))
+  })
+}
+
+export function testInstantiatedStore() {
+  render(SomeComponent, {
+    store: new Vuex.Store({
+      state: {count: 3},
+      mutations: {
+        increment(state) {
+          state.count++
+        },
+        decrement(state) {
+          state.count--
+        },
+      },
+      actions: {
+        increment(context) {
+          context.commit('increment')
+        },
+        decrement(context) {
+          context.commit('decrement')
+        },
+      },
+    }),
   })
 }
 


### PR DESCRIPTION
As currently written, the `store` property passed to the `render` function must be `StoreOptions`, which is a plain Javascript object passed to `new Vuex.Store()` in the render function.

This is great for simple components and should definitely still be a supported option. However, it would be really useful for us to be able to pass a complex, instantiated Vuex store (generated by our common test helpers) as well.

This PR accomplishes this behavior by checking if the passed `store` is an `instance of Vuex.Store` and skipping the `new Vuex.Store()` call in that case.

If this seems reasonable, I can also update the API documentation in the other repository 😄 . Thanks for your time & consideration!