### PR TITLE
fix: use Vue Router in abstract mode

### DIFF
--- a/src/__tests__/vue-router.js
+++ b/src/__tests__/vue-router.js
@@ -32,3 +32,9 @@ test('setting initial route', () => {
 
   expect(getByTestId('location-display')).toHaveTextContent('/about')
 })
+
+test('router state is not shared between tests', () => {
+  const {getByTestId} = render(App, {routes})
+
+  expect(getByTestId('location-display')).toHaveTextContent('/')
+})

--- a/src/render.js
+++ b/src/render.js
@@ -39,7 +39,8 @@ function render(
     const VueRouter = requiredRouter.default || requiredRouter
     localVue.use(VueRouter)
 
-    router = new VueRouter({routes})
+    router = new VueRouter({routes, mode: 'abstract'})
+    router.push('/')
   }
 
   if (configurationCb && typeof configurationCb === 'function') {


### PR DESCRIPTION
This PR uses `mode: 'abstract'` when creating a Vue Router instance.

By default, the Vue Router uses 'hash' mode ([docs](https://router.vuejs.org/api/#mode)) which, in test environments with JSDOM, updates the `window.location.href` hash value. In jest, the JSDOM environment is not reset between tests, which means that state appears to leak between tests, as mentioned in #210.

I did some digging through the vue-test-utils issue tracker and found https://github.com/vuejs/vue-test-utils/issues/1681, which talks about this issue in more depth. The recommended solution from that thread is to use `abstract` mode, which guarantees you start with a clean Vue Router each time it's instantiated.

Alternately, if this solution does not seem acceptable, users can utilize a lifecycle hook, such as Jest's `beforeEach` to reset the state between tests. For example:

```ts
beforeEach(() => {
  window.location.replace('http://localhost/');
});
```

Fixes #210