### PR TITLE
feat: allow passing instantiated Vue Router

### DIFF
--- a/src/__tests__/vue-router.js
+++ b/src/__tests__/vue-router.js
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom'
 import {render, fireEvent} from '@testing-library/vue'
+import VueRouter from 'vue-router'
 
 import App from './components/Router/App.vue'
 import Home from './components/Router/Home.vue'
@@ -31,4 +32,16 @@ test('setting initial route', () => {
   })
 
   expect(getByTestId('location-display')).toHaveTextContent('/about')
+})
+
+test('can render with an instantiated Vuex store', async () => {
+  // Instantiate a router with only one route
+  const instantiatedRouter = new VueRouter({
+    routes: [{path: '/special-path', component: Home}],
+  })
+
+  render(App, {routes: instantiatedRouter}, (vue, store, router) => {
+    expect(router.getRoutes()).toHaveLength(1)
+    expect(router.getRoutes()[0].path).toEqual('/special-path')
+  })
 })

--- a/src/render.js
+++ b/src/render.js
@@ -39,7 +39,7 @@ function render(
     const VueRouter = requiredRouter.default || requiredRouter
     localVue.use(VueRouter)
 
-    router = new VueRouter({routes})
+    router = routes instanceof VueRouter ? routes : new VueRouter({routes})
   }
 
   if (configurationCb && typeof configurationCb === 'function') {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -41,7 +41,7 @@ export interface RenderOptions<V extends Vue, S = {}>
   extends Omit<ThisTypedMountOptions<V>, 'store' | 'props'> {
   props?: object
   store?: StoreOptions<S>
-  routes?: RouteConfig[]
+  routes?: RouteConfig[] | Router
   container?: Element
   baseElement?: Element
 }

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
+import VueRouter from 'vue-router'
 import {render, fireEvent, screen, waitFor} from '@testing-library/vue'
 
 declare const elem: Element
@@ -148,6 +149,14 @@ export function testInstantiatedStore() {
           context.commit('decrement')
         },
       },
+    }),
+  })
+}
+
+export function testInstantiatedRouter() {
+  render(SomeComponent, {
+    routes: new VueRouter({
+      routes: [{path: '/', name: 'home', component: SomeComponent}],
     }),
   })
 }


### PR DESCRIPTION
This PR supersedes #238 and is similar to #232. If `routes` is an instantiated Vue Router, it will be used instead of creating a new Vue Router. This allows developers to use `abstract` mode to avoid the issue described in #210.

Fixes #210 

See also docs upates here: https://github.com/testing-library/testing-library-docs/pull/875