### PR TITLE
fix(types): Remove Router and Vuex dependency from types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,8 +2,6 @@
 
 import Vue, {ComponentOptions} from 'vue'
 import {ThisTypedMountOptions, VueClass} from '@vue/test-utils'
-import {Store, StoreOptions} from 'vuex'
-import Router, {RouteConfig} from 'vue-router'
 // eslint-disable-next-line import/no-extraneous-dependencies
 import {
   queries,
@@ -36,12 +34,19 @@ export interface RenderResult extends BoundFunctions<typeof queries> {
   updateProps(props: object): Promise<void>
 }
 
-export interface RenderOptions<V extends Vue, S = {}>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Store = any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Routes = any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Router = any
+
+export interface RenderOptions<V extends Vue>
   // The props and store options special-cased by Vue Testing Library and NOT passed to mount().
   extends Omit<ThisTypedMountOptions<V>, 'store' | 'props'> {
   props?: object
-  store?: StoreOptions<S>
-  routes?: RouteConfig[] | Router
+  store?: Store
+  routes?: Routes
   container?: Element
   baseElement?: Element
 }
@@ -50,11 +55,11 @@ export type ConfigurationCallback<V extends Vue> =
   | ((
       localVue: typeof Vue,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      store: Store<any>,
+      store: Store,
       router: Router,
     ) => Partial<ThisTypedMountOptions<V>>)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  | ((localVue: typeof Vue, store: Store<any>, router: Router) => void)
+  | ((localVue: typeof Vue, store: Store, router: Router) => void)
 
 export function render<V extends Vue>(
   TestComponent: VueClass<V> | ComponentOptions<V>,

--- a/types/test.ts
+++ b/types/test.ts
@@ -110,11 +110,6 @@ export function testOptions() {
         foos: [4, 5],
         bars: ['a', 'b'],
       },
-      getters: {
-        fooCount() {
-          return this.foos.length
-        },
-      },
     },
     routes: [
       {path: '/', name: 'home', component: SomeComponent},
@@ -129,10 +124,8 @@ export function testOptions() {
 
 export function testConfigCallback() {
   const ExamplePlugin: Vue.PluginFunction<never> = () => {}
-  render(SomeComponent, {}, (localVue, store, router) => {
+  render(SomeComponent, {}, localVue => {
     localVue.use(ExamplePlugin)
-    store.replaceState({foo: 'bar'})
-    router.onError(error => console.log(error.message))
   })
 }
 


### PR DESCRIPTION
Closes https://github.com/testing-library/vue-testing-library/issues/187

I'm not entirely sure this is the best way to fix the issue, but I want to get the ball rolling.