### PR TITLE
feat: Expose the component instance

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -75,6 +75,7 @@ function render(
     html: () => wrapper.html(),
     emitted: () => wrapper.emitted(),
     updateProps: _ => wrapper.setProps(_),
+    vm: wrapper.vm,
     ...getQueriesForElement(baseElement),
   }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -32,6 +32,7 @@ export interface RenderResult extends BoundFunctions<typeof queries> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   emitted(): {[name: string]: any[][]}
   updateProps(props: object): Promise<void>
+  vm: Vue
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Thanks for the awesome project! I've really enjoyed using it over at WordPress/Gutenberg and now introducing it to WordPress/openverse-frontend. It's been a great tool for learning and teaching people how to test with a focus on accessibility. Again, thanks so much!

I ran into this issue today so I decided to open a PR that would help me solve the issue, hope that's okay! This would also solve some of the issues found in this issue: #92

By exposing the `vm` from the `@vue/test-utils` wrapper, it'll allow doing things like calling `Component.fetch.call(wrapper.vm)` which is necessary becuase by default Vue doesn't call the "extra" Nuxt lifecycle methods (more about those here https://nuxtjs.org/docs/2.x/components-glossary/pages-fetch)

Maybe there's another more complex approach that would work more seamlessly (like adding a plugin that calls these methods for you or something) but this seems like the simplest option, just exposing the component instance that you'd get if you just used `@vue/test-utils` directly.