### PR TITLE
chore: pin `@vue/test-utils` version to `^2.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@babel/runtime": "^7.15.4",
     "@testing-library/dom": "^8.5.0",
-    "@vue/test-utils": "^2.0.0-rc.18"
+    "@vue/test-utils": "^2.0.0"
   },
   "devDependencies": {
     "@apollo/client": "^3.4.11",


### PR DESCRIPTION
I expect nothing will break

cc @afontcu 