### PR TITLE
fix: add missed optional prop for emmited function

### DIFF
--- a/src/__tests__/form.js
+++ b/src/__tests__/form.js
@@ -62,6 +62,6 @@ test('Review form submits', async () => {
 
   // Assert the right event has been emitted.
   expect(emitted()).toHaveProperty('submit')
-  expect(emitted().submit[0][0]).toMatchObject(fakeReview)
+  expect(emitted('submit')[0][0]).toMatchObject(fakeReview)
   expect(console.warn).not.toHaveBeenCalled()
 })

--- a/src/__tests__/user-event.js
+++ b/src/__tests__/user-event.js
@@ -53,7 +53,7 @@ test('User events in a form', async () => {
   expect(submitButton).toHaveFocus()
   expect(submitButton).toBeEnabled()
   userEvent.type(submitButton, '{enter}')
-  expect(emitted().submit[0][0]).toMatchObject(fakeReview)
+  expect(emitted('submit')[0][0]).toMatchObject(fakeReview)
 
   expect(console.warn).not.toHaveBeenCalled()
 })

--- a/src/render.js
+++ b/src/render.js
@@ -45,7 +45,7 @@ Check out the test examples on GitHub for further details.`)
         : console.log(prettyDOM(el, maxLength, options)),
     unmount: () => wrapper.unmount(),
     html: () => wrapper.html(),
-    emitted: () => wrapper.emitted(),
+    emitted: name => wrapper.emitted(name),
     rerender: props => wrapper.setProps(props),
     ...getQueriesForElement(baseElement),
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -24,6 +24,7 @@ export interface RenderResult extends BoundFunctions<typeof queries> {
   unmount(): void
   html(): string
   emitted<T = unknown>(): Record<string, T[]>
+  emitted<T = unknown>(name?: string): T[]
   rerender(props: object): Promise<void>
 }
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -86,6 +86,7 @@ export function testOptions() {
 export function testEmitted() {
   const {emitted} = render(SomeComponent)
   expectType<unknown[]>(emitted().foo)
+  expectType<unknown[]>(emitted('foo'))
 }
 
 /*


### PR DESCRIPTION
Vue test utils allow to pass event name  into `emitted()` to receive array of calls
`emitted().foo` can be written as `emitted('foo')`
You can see it [here](https://test-utils.vuejs.org/api/#emitted)