### PR TITLE
fix: align rerender with VTL and RTL

### DIFF
--- a/src/__tests__/rerender.js
+++ b/src/__tests__/rerender.js
@@ -14,14 +14,13 @@ test('rerender re-renders the element', async () => {
 
   expect(getByTestId('number-display')).toHaveTextContent('1')
 
-  await rerender({number: 3})
+  rerender({props: {number: 3}})
   expect(getByTestId('number-display')).toHaveTextContent('3')
 
-  await rerender({number: 5})
+  rerender({props: {number: 5}})
   expect(getByTestId('number-display')).toHaveTextContent('5')
 
-  // Notice we don't remount a different instance
-  expect(getByTestId('instance-id')).toHaveTextContent('1')
+  expect(getByTestId('instance-id')).toHaveTextContent('3')
 })
 
 test('rerender works with composition API', async () => {
@@ -46,7 +45,7 @@ test('rerender works with composition API', async () => {
 
   expect(getContent()).toHaveTextContent('Foo is: foo. Foobar is: foo-bar')
 
-  await rerender({foo: 'qux'})
+  rerender({props: {foo: 'qux'}})
 
   expect(getContent()).toHaveTextContent('Foo is: qux. Foobar is: qux-bar')
 })

--- a/src/render.js
+++ b/src/render.js
@@ -46,7 +46,10 @@ Check out the test examples on GitHub for further details.`)
     unmount: () => wrapper.unmount(),
     html: () => wrapper.html(),
     emitted: name => wrapper.emitted(name),
-    rerender: props => wrapper.setProps(props),
+    rerender: options => {
+      cleanup()
+      render(Component, options)
+    },
     ...getQueriesForElement(baseElement),
   }
 }


### PR DESCRIPTION
fix for: https://github.com/testing-library/vue-testing-library/issues/198. To stir up this discussion.. I don't think you should deviate from RTL and STL unless there is a strong case against doing so. As far as i've seen it isn't there.