### PR TITLE
fix: use flushPromise() instead of waitFor()

### DIFF
--- a/src/fire-event.js
+++ b/src/fire-event.js
@@ -1,5 +1,5 @@
-/* eslint-disable testing-library/no-wait-for-empty-callback */
-import {waitFor, fireEvent as dtlFireEvent} from '@testing-library/dom'
+import {fireEvent as dtlFireEvent} from '@testing-library/dom'
+import {flushPromises} from '@vue/test-utils'
 
 // Vue Testing Lib's version of fireEvent will call DOM Testing Lib's
 // version of fireEvent. The reason is because we need to wait another
@@ -8,7 +8,7 @@ import {waitFor, fireEvent as dtlFireEvent} from '@testing-library/dom'
 
 async function fireEvent(...args) {
   dtlFireEvent(...args)
-  await waitFor(() => {})
+  await flushPromises()
 }
 
 Object.keys(dtlFireEvent).forEach(key => {
@@ -16,7 +16,7 @@ Object.keys(dtlFireEvent).forEach(key => {
     warnOnChangeOrInputEventCalledDirectly(args[1], key)
 
     dtlFireEvent[key](...args)
-    await waitFor(() => {})
+    await flushPromises()
   }
 })
 


### PR DESCRIPTION
The current fireEvent() uses waitFor() after calling the event listener's callback function to ensure that the DOM is updated in a timely manner, passing in an empty function and awaiting it. `await waitFor (() => {})` returns a promise that resolves shortly after. Since Vue also uses promises or other microtasks to update the DOM, when the microtask generated by the promise returned by calling waitFor() is executed by the event loop, the microtask of updating the DOM can also be executed. Users only needs to await fireEvent() to ensure the update of the DOM.

This seems very reasonable. But in some cases, such handling can cause some problems, causing the update of the DOM to be performed after the assertion written by the user.

The case is: some component libraries, like [vant](https://github.com/vant-ui/vant/blob/main/packages/vant/src/form/Form.tsx), encapsulate form that perform form validation before calling the event callback passed by the user when processing the submit event, and their function for validation will use nested promises to do check (usually a combination of promise and `Promise.all()`), which leads to a problem: when the microtask generated by waitFor() is executed, the microtask of Vue's update DOM has not been executed! So the user's assertion will be executed earlier than the task of updating the DOM, causing the test to fail.

This situation can be reproducted as follows:

```
const validate = () => {
  return new Promise((resolve) => {
    Promise.resolve().then(() => {
      resolve(1)
    })
  })
}

const submit = () => {
  validate().then(() => {
    // Simulate Vue to generate microtasks that update the DOM
    Promise.resolve().then(() => {
      console.log('dom update')
    })
  })
}

const fireEvent = async () => {
  submit()// submit the form
  await Promise.resolve()// simulate waitFor( () => {} )
}

const myTest = async () => {
  await fireEvent()
  
  console.log('assertion')
}

myTest()
```
I also provide a reproduction [here](https://github.com/joeyhuang0235/vitejs-vite-ruvztf).

Obviously, the above situation is not in line with the design purpose of fireEvent() and the expectations of users. Users who do not know the reason may wonder whether the implementation of their source code is wrong or whether there is a problem with the test code, but will not think it's a problem with fireEvent() itself, because the doc they've seen tells them that the function is guaranteed to update the dom.

For users, one solution is to use waitFor() to wrap the assertion and wait for the dom to update. This can let the test to pass, but also adds redundant code. It also makes users lose confidence in writing test code, because they can't be sure that the dom will update immediately after they call and `await fireEvent()`.

So I think it is necessary to modify the internal implementation of fireEvent(). I use the [flushPromise()](https://github.com/vuejs/test-utils/blob/main/src/utils/flushPromises.ts) exported by vue/test-utils instead of waitFor(). In addition to using promises, flushPromise() calls setImmediate/setTimeout to generate a macroTask that calls the resolve() method. Since the macroTask will be executed after the microTask, this ensures that all microTasks generated after the fireEvent() call, including DOM updates, will be executed before the macroTask. So replacing waitFor() with flushPromises() guarantees that dom updates can be done before the user's assertion.