### PR TITLE
feat: use "object literal" instead of "switch" condition

### DIFF
--- a/src/fire-event/fire-event.js
+++ b/src/fire-event/fire-event.js
@@ -1,5 +1,6 @@
 /* eslint-disable testing-library/no-wait-for-empty-callback */
 import {waitFor, fireEvent as dtlFireEvent} from '@testing-library/dom'
+import {useActions, InputTypeActions} from './input-type-actions'
 
 // Vue Testing Lib's version of fireEvent will call DOM Testing Lib's
 // version of fireEvent. The reason is because we need to wait another
@@ -30,48 +31,15 @@ fireEvent.touch = async elem => {
 // Related upstream issue: https://github.com/vuejs/vue-test-utils/issues/345#issuecomment-380588199
 // See some examples in __tests__/form.js
 fireEvent.update = (elem, value) => {
-  const tagName = elem.tagName
-  const type = elem.type
+  const {tagName} = elem
 
-  switch (tagName) {
-    case 'OPTION': {
-      elem.selected = true
-
-      const parentSelectElement =
-        elem.parentElement.tagName === 'OPTGROUP'
-          ? elem.parentElement.parentElement
-          : elem.parentElement
-
-      return fireEvent.change(parentSelectElement)
-    }
-
-    case 'INPUT': {
-      if (['checkbox', 'radio'].includes(type)) {
-        elem.checked = true
-        return fireEvent.change(elem)
-      } else if (type === 'file') {
-        return fireEvent.change(elem)
-      } else {
-        elem.value = value
-        return fireEvent.input(elem)
-      }
-    }
-
-    case 'TEXTAREA': {
-      elem.value = value
-      return fireEvent.input(elem)
-    }
-
-    case 'SELECT': {
-      elem.value = value
-      return fireEvent.change(elem)
-    }
-
-    default:
-    // do nothing
+  if (!InputTypeActions[tagName.toUpperCase()]) {
+    return null
   }
 
-  return null
+  const {[tagName.toUpperCase()]: inputAction} = useActions(fireEvent)
+
+  return inputAction(elem, value)
 }
 
 function warnOnChangeOrInputEventCalledDirectly(eventValue, eventKey) {

--- a/src/fire-event/index.js
+++ b/src/fire-event/index.js
@@ -1,0 +1,1 @@
+export * from './fire-event'

--- a/src/fire-event/input-type-actions.js
+++ b/src/fire-event/input-type-actions.js
@@ -1,0 +1,41 @@
+export const InputTypeActions = {
+  OPTION: 'OPTION',
+  INPUT: 'INPUT',
+  TEXTAREA: 'TEXTAREA',
+  SELECT: 'SELECT',
+}
+
+export const useActions = fireEvent => ({
+  [InputTypeActions.OPTION]: elem => {
+    elem.selected = true
+
+    const parentSelectElement =
+      elem.parentElement.tagName === 'OPTGROUP'
+        ? elem.parentElement.parentElement
+        : elem.parentElement
+
+    return fireEvent.change(parentSelectElement)
+  },
+  [InputTypeActions.INPUT]: (elem, value) => {
+    const {type} = elem
+
+    if (['checkbox', 'radio', 'file'].includes(type)) {
+      if (type !== 'file') {
+        elem.checked = true
+      }
+
+      return fireEvent.change(elem)
+    }
+
+    elem.value = value
+    return fireEvent.input(elem)
+  },
+  [InputTypeActions.TEXTAREA]: (elem, value) => {
+    elem.value = value
+    return fireEvent.input(elem)
+  },
+  [InputTypeActions.SELECT]: (elem, value) => {
+    elem.value = value
+    return fireEvent.change(elem)
+  },
+})


### PR DESCRIPTION
# Description
> The file `fire-event.js` had a `switch` statement to handle the `fireEvent.update` function. In this PR the file was moved into a folder called "fire-event" and a new File called "input-type-actions.js" has been created. In this file, the previous switch logic has been moved and adapted in order to use an `Object literal` pattern.

# Changes
- Instead of using a Switch, an Object has been created
- There are **no** breaking changes
- Same tests are running and passing as in previous version
- Code has been cleaned and optimised