### PR TITLE
chore: optional compiler-sfc

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,11 @@
     "@vue/compiler-sfc": ">= 3",
     "vue": ">= 3"
   },
+  "peerDependenciesMeta": {
+    "@vue/compiler-sfc": {
+      "optional": true
+    }
+  },
   "husky": {
     "hooks": {
       "pre-commit": "kcd-scripts pre-commit"


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

Close #272.

Refer to the [README](https://www.npmjs.com/package/@vue/compiler-sfc), after `v3.2.13`, the `@vue/compiler-sfc` can be optional because it has already been included in the `vue` package.

So I mark this peer dependency as optional.