### PR TITLE
Throw error when running vitest with no afterEach global and no VTL_SKIP_AUTO_CLEANUP

### DIFF
--- a/src/__tests__/auto-cleanup-vitest-globals.js
+++ b/src/__tests__/auto-cleanup-vitest-globals.js
@@ -1,0 +1,7 @@
+// This test verifies that if test is running from vitest with globals - jest will not throw
+test('works', () => {
+  global.afterEach = () => {} // emulate enabled globals
+  process.env.VITEST = 'true'
+
+  expect(() => require('..')).not.toThrow()
+})

--- a/src/__tests__/auto-cleanup-vitest.js
+++ b/src/__tests__/auto-cleanup-vitest.js
@@ -1,0 +1,10 @@
+// This test verifies that if test is running from vitest without globals - jest will throw
+test('works', () => {
+  delete global.afterEach // no globals in vitest by default
+  process.env.VITEST = 'true'
+
+  expect(() => require('..')).toThrowErrorMatchingInlineSnapshot(`
+    You are using vitest without globals, this way we can't run cleanup after each test.
+    See https://testing-library.com/docs/vue-testing-library/setup for details or set the VTL_SKIP_AUTO_CLEANUP variable to 'true'
+  `)
+})

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,11 @@ if (typeof afterEach === 'function' && !process.env.VTL_SKIP_AUTO_CLEANUP) {
   afterEach(() => {
     cleanup()
   })
+} else if (process.env.VITEST === 'true') {
+  throw new Error(
+    "You are using vitest without globals, this way we can't run cleanup after each test.\n" +
+      "See https://testing-library.com/docs/vue-testing-library/setup for details or set the VTL_SKIP_AUTO_CLEANUP variable to 'true'",
+  )
 }
 
 export * from '@testing-library/dom'


### PR DESCRIPTION
This partially addresses https://github.com/testing-library/vue-testing-library/issues/296 and will make more sense after docs are updated