### PR TITLE
Warn Developers Lacking a Global `afterEach` Function Instead of Throwing Errors

### DIFF
--- a/src/__tests__/auto-cleanup-global-env.js
+++ b/src/__tests__/auto-cleanup-global-env.js
@@ -1,3 +1,13 @@
+beforeEach(jest.restoreAllMocks)
+
+test('Testing Utilities with global access to `afterEach()` will not log warnings', () => {
+  jest.spyOn(console, 'warn')
+  global.afterEach = () => {}
+
+  require('..')
+  expect(console.warn).not.toHaveBeenCalled()
+})
+
 test('Testing Utilities lacking a global `afterEach` function will log a warning ONCE', () => {
   delete global.afterEach
   const warn = jest.spyOn(console, 'warn')

--- a/src/__tests__/auto-cleanup-vitest-globals.js
+++ b/src/__tests__/auto-cleanup-vitest-globals.js
@@ -1,7 +1,0 @@
-test('Testing Utilities with global access to `afterEach()` will not log warnings', () => {
-  jest.spyOn(console, 'warn')
-  global.afterEach = () => {}
-
-  require('..')
-  expect(console.warn).not.toHaveBeenCalled()
-})

--- a/src/__tests__/auto-cleanup-vitest-globals.js
+++ b/src/__tests__/auto-cleanup-vitest-globals.js
@@ -1,7 +1,7 @@
-// This test verifies that if test is running from vitest with globals - jest will not throw
-test('works', () => {
-  global.afterEach = () => {} // emulate enabled globals
-  process.env.VITEST = 'true'
+test('Testing Utilities with global access to `afterEach()` will not log warnings', () => {
+  jest.spyOn(console, 'warn')
+  global.afterEach = () => {}
 
-  expect(() => require('..')).not.toThrow()
+  require('..')
+  expect(console.warn).not.toHaveBeenCalled()
 })

--- a/src/__tests__/auto-cleanup-vitest.js
+++ b/src/__tests__/auto-cleanup-vitest.js
@@ -1,10 +1,13 @@
-// This test verifies that if test is running from vitest without globals - jest will throw
-test('works', () => {
-  delete global.afterEach // no globals in vitest by default
-  process.env.VITEST = 'true'
+test('Testing Utilities lacking a global `afterEach` function will log a warning ONCE', () => {
+  delete global.afterEach
+  const warn = jest.spyOn(console, 'warn')
 
-  expect(() => require('..')).toThrowErrorMatchingInlineSnapshot(`
-    You are using vitest without globals, this way we can't run cleanup after each test.
-    See https://testing-library.com/docs/vue-testing-library/setup for details or set the VTL_SKIP_AUTO_CLEANUP variable to 'true'
-  `)
+  require('..')
+  jest.resetModules()
+  require('..')
+
+  expect(warn).toHaveBeenCalledTimes(1)
+  expect(warn.mock.calls[0][0]).toMatchInlineSnapshot(
+    `The current test runner does not support afterEach/teardown hooks. This means we won't be able to run automatic cleanup and you should be calling cleanup() manually.`,
+  )
 })

--- a/src/index.js
+++ b/src/index.js
@@ -5,9 +5,7 @@ import {cleanup} from './render'
 // This ensures that tests run in isolation from each other.
 // If you don't like this, set the VTL_SKIP_AUTO_CLEANUP variable to 'true'.
 if (typeof afterEach === 'function' && !process.env.VTL_SKIP_AUTO_CLEANUP) {
-  afterEach(() => {
-    cleanup()
-  })
+  afterEach(cleanup)
 } else if (!process.env.VTL_AFTEREACH_WARNING_LOGGED) {
   process.env.VTL_AFTEREACH_WARNING_LOGGED = true
   console.warn(

--- a/src/index.js
+++ b/src/index.js
@@ -8,10 +8,10 @@ if (typeof afterEach === 'function' && !process.env.VTL_SKIP_AUTO_CLEANUP) {
   afterEach(() => {
     cleanup()
   })
-} else if (process.env.VITEST === 'true') {
-  throw new Error(
-    "You are using vitest without globals, this way we can't run cleanup after each test.\n" +
-      "See https://testing-library.com/docs/vue-testing-library/setup for details or set the VTL_SKIP_AUTO_CLEANUP variable to 'true'",
+} else if (!process.env.VTL_AFTEREACH_WARNING_LOGGED) {
+  process.env.VTL_AFTEREACH_WARNING_LOGGED = true
+  console.warn(
+    `The current test runner does not support afterEach/teardown hooks. This means we won't be able to run automatic cleanup and you should be calling cleanup() manually.`,
   )
 }
 


### PR DESCRIPTION
## Changes
- Warn developers who aren't using a global `afterEach` function instead of throwing errors.
- Minor formatting/style changes (in related files only; optional)

## Why?

I gave some reasons for why I think this direction of change is desirable in #297 -- specifically [here](https://github.com/testing-library/vue-testing-library/pull/297#issuecomment-1800939145) and [here](https://github.com/testing-library/vue-testing-library/pull/297#issuecomment-1801071909). But here's a brief set of reasons for why I think this is the way to go:

1) **Developer Experience**. Throwing errors at developers who _intentionally_ don't use globals is a really painful DX. Yes, there are workarounds, but any workaround for this problem will admittedly be clunky (and therefore another bad DX).
2) **Fragility**. The current implementation of the `afterEach` absence check is very brittle because it only considers `Vitest`. If we're thinking about the longterm strength of this project, it needs to be able to consider all possible test runners. Only considering one test runner is insufficient, and bloating the `if`/`else` checks for every new test runner that gets released will eventually become unmaintainable. Moreover, since it's an internal implementation detail, `Vitest` can change the ENV variable that they use at any moment (again, making the existing check brittle).
3) **Convention**: Although `Vitest` shares many similarities with `Jest`, it also has some intentional differences. For instance, [_Vitest intentionally refuses to use globals by default_](https://vitest.dev/guide/migration.html#globals-as-a-default). To create a scenario in VTL that requires Vitest users to use globals (by default) goes against the natural flow of Vitest, and it may disrupt several Vitest users in the process.
4) **Documentation**: Both [Vitest](https://vitest.dev/guide/migration.html#globals-as-a-default) and [VTL](https://testing-library.com/docs/vue-testing-library/api#cleanup) already document the fact that you must setup `afterEach(cleanup)` manually if globals are not available for your test runner. The point of the documentation is to catch these exact pitfalls. If the people migrating from Jest to Vitest aren't using the Migration Guide, and if the people using VTL aren't reading the VTL docs, then there isn't really much that the maintainers can accomplish for their users. The docs are very accessible. (I used them to handle my `cleanup` errors.) But the developer still has to reach for them. And maintainers can only go so far without harming other developers' experiences (e.g., throwing errors when globals aren't available) or making the logs/JSDocs overwhelming. Throwing errors harms DX while negating the point of the docs; so I feel it's best to avoid this.