### PR TITLE
chore: Update @vue/test-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@babel/runtime": "^7.23.2",
     "@testing-library/dom": "^9.3.3",
-    "@vue/test-utils": "^2.4.1"
+    "@vue/test-utils": "^2.4.6"
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-methods": "^7.18.6",


### PR DESCRIPTION
This Change fixes broken stubs when using the latest Vue version.

See the following links for more context:

- https://github.com/vuejs/test-utils/pull/2413
- https://github.com/vuejs/test-utils/issues/2411

## Info for yarn@1 users

If you can't wait for this PR to be merged & shipped you can use [yarn resolutions](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/) to force the correct `@vue/test-utils` version.

**package.json**

```diff
+  "resolutions": {
+    "@testing-library/vue/@vue/test-utils": "^v2.4.6"
+  }
```