### PR TITLE
Fix #315 - RemoveIndexSignature deprecated in v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "lodash.merge": "^4.6.2",
     "msw": "^1.3.2",
     "tsd": "^0.29.0",
-    "type-fest": "~2.19",
+    "type-fest": ">=2.10 <4.0.0",
     "typescript": "^5.2.2",
     "vee-validate": "^4.11.8",
     "vue": "^3.3.5",


### PR DESCRIPTION
`RemoveIndexSignature` added in `type-fest` [v2.10.0](https://github.com/sindresorhus/type-fest/releases/tag/v2.10.0). Renamed to `OmitIndexSignature` in [v4.0.0](https://github.com/sindresorhus/type-fest/releases/tag/v4.0.0). `package.json` updated to reflect compatibility.